### PR TITLE
feat: improve signer verification

### DIFF
--- a/contracts/TransactionInvoker.sol
+++ b/contracts/TransactionInvoker.sol
@@ -43,7 +43,7 @@ contract TransactionInvoker {
 
     bytes32 public constant TRANSACTION_TYPE =
         keccak256(
-            "Transaction(address from, uint256 nonce,TransactionPayload[] payload)TransactionPayload(address to,uint256 value,uint256 gasLimit,bytes data)"
+            "Transaction(address from,uint256 nonce,TransactionPayload[] payload)TransactionPayload(address to,uint256 value,uint256 gasLimit,bytes data)"
         );
 
     bytes32 public constant TRANSACTION_PAYLOAD_TYPE =

--- a/contracts/TransactionInvoker.sol
+++ b/contracts/TransactionInvoker.sol
@@ -43,7 +43,7 @@ contract TransactionInvoker {
 
     bytes32 public constant TRANSACTION_TYPE =
         keccak256(
-            "Transaction(uint256 nonce,TransactionPayload[] payload)TransactionPayload(address to,uint256 value,uint256 gasLimit,bytes data)"
+            "Transaction(address from, uint256 nonce,TransactionPayload[] payload)TransactionPayload(address to,uint256 value,uint256 gasLimit,bytes data)"
         );
 
     bytes32 public constant TRANSACTION_PAYLOAD_TYPE =
@@ -62,6 +62,7 @@ contract TransactionInvoker {
     }
 
     struct Transaction {
+        address from;
         uint256 nonce;
         TransactionPayload[] payload;
     }
@@ -99,7 +100,7 @@ contract TransactionInvoker {
         require(transaction.payload.length > 0, "No transaction payload");
 
         address signer = authenticate(signature, transaction);
-        require(signer != address(0), "Invalid signature");
+        require(signer == transaction.from, "Invalid signature");
         require(transaction.nonce == nonces[signer], "Invalid nonce");
 
         nonces[signer] += 1;
@@ -202,6 +203,7 @@ contract TransactionInvoker {
             keccak256(
                 abi.encode(
                     TRANSACTION_TYPE,
+                    transaction.from,
                     transaction.nonce,
                     hash(transaction.payload)
                 )

--- a/scripts/signing/payload.json
+++ b/scripts/signing/payload.json
@@ -7,6 +7,7 @@
       { "name": "verifyingContract", "type": "address" }
     ],
     "Transaction": [
+      { "name": "from", "type": "address" },
       { "name": "nonce", "type": "uint256" },
       { "name": "payload", "type": "TransactionPayload[]" }
     ],

--- a/test/TransactionInvoker.ts
+++ b/test/TransactionInvoker.ts
@@ -78,7 +78,7 @@ describe("TransactionInvoker", () => {
       const transactionType = ethers.utils.solidityKeccak256(
         ["string"],
         [
-          "Transaction(address from, uint256 nonce,TransactionPayload[] payload)TransactionPayload(address to,uint256 value,uint256 gasLimit,bytes data)",
+          "Transaction(address from,uint256 nonce,TransactionPayload[] payload)TransactionPayload(address to,uint256 value,uint256 gasLimit,bytes data)",
         ]
       );
       const transactionPayloadType = ethers.utils.solidityKeccak256(

--- a/test/TransactionInvoker.ts
+++ b/test/TransactionInvoker.ts
@@ -78,7 +78,7 @@ describe("TransactionInvoker", () => {
       const transactionType = ethers.utils.solidityKeccak256(
         ["string"],
         [
-          "Transaction(uint256 nonce,TransactionPayload[] payload)TransactionPayload(address to,uint256 value,uint256 gasLimit,bytes data)",
+          "Transaction(address from, uint256 nonce,TransactionPayload[] payload)TransactionPayload(address to,uint256 value,uint256 gasLimit,bytes data)",
         ]
       );
       const transactionPayloadType = ethers.utils.solidityKeccak256(
@@ -125,6 +125,7 @@ describe("TransactionInvoker", () => {
     it("Should revert on no payload", async () => {
       const nonce = await invoker.nonces(alice.address);
       const messageWithoutPayload = {
+        from: alice.address,
         nonce: nonce,
         payload: [],
       };
@@ -138,6 +139,7 @@ describe("TransactionInvoker", () => {
     it("Should revert on invalid signature", async () => {
       const nonce = await invoker.nonces(alice.address);
       const message = {
+        from: alice.address,
         nonce: nonce,
         payload: [
           { to: mock.address, value: 0, gasLimit: 1000000, data: increment },
@@ -152,6 +154,7 @@ describe("TransactionInvoker", () => {
     it("Should revert on invalid nonce", async () => {
       const invalidNonce = (await invoker.nonces(alice.address)).add("1");
       const messageWithInvalidNonce = {
+        from: alice.address,
         nonce: invalidNonce,
         payload: [
           { to: mock.address, value: 0, gasLimit: 1000000, data: increment },
@@ -167,6 +170,7 @@ describe("TransactionInvoker", () => {
     it("Should revert on call failure", async () => {
       const nonce = await invoker.nonces(alice.address);
       const messageWithRevertingCall = {
+        from: alice.address,
         nonce: nonce,
         payload: [
           { to: mock.address, value: 0, gasLimit: 1000000, data: increment },
@@ -183,6 +187,7 @@ describe("TransactionInvoker", () => {
     it("Should revert on leftover value", async () => {
       const nonce = await invoker.nonces(alice.address);
       const message = {
+        from: alice.address,
         nonce: nonce,
         payload: [
           { to: mock.address, value: 0, gasLimit: 1000000, data: increment },
@@ -198,6 +203,7 @@ describe("TransactionInvoker", () => {
     it("Should bundle transactions", async () => {
       const nonce = await invoker.nonces(alice.address);
       const message = {
+        from: alice.address,
         nonce,
         payload: [
           {
@@ -245,6 +251,7 @@ describe("TransactionInvoker", () => {
     it("Enables transaction sponsoring", async () => {
       const nonce = await invoker.nonces(alice.address);
       const message = {
+        from: alice.address,
         nonce,
         payload: [
           {


### PR DESCRIPTION
## Motivation

If the signature or data is manipulated, the invoker will usually recover *some* address, instead of `address(0)`.

## Solution

Add `from` field to `Transaction` and require that the recovered address is the `from` address.