### PR TITLE
docs: explain signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Account Abstraction Invoker uses [`AUTH`](https://eips.ethereum.org/EIPS/eip-307
 
 Use cases are showcased in the [tests](test/TransactionInvoker.ts).
 
+[Commit](https://eips.ethereum.org/EIPS/eip-3074#understanding-commit) is EIP-712 hash of the this [structure](scripts/signing/README.md).
+
 ## Requirements
 
 - Network with EIP-3074

--- a/scripts/signing/README.md
+++ b/scripts/signing/README.md
@@ -1,0 +1,59 @@
+## Signing
+
+Call `getSignature` with `message` and `privateKey`:
+
+```typescript
+const message = {
+  from: 0x0000000000000000000000000000000000000000,
+  nonce: nonce,
+  payload: [
+    { to: "0x0000000000000000000000000000000000000000", value: 0, gasLimit: 0, data: "0x" }
+  ],
+};
+const signature = getSignature(message, privateKey);
+```
+
+`getSignature` will sign EIP-712 hash of the following data:
+
+```json
+{
+  "types": {
+    "EIP712Domain": [
+      { "name": "name", "type": "string" },
+      { "name": "version", "type": "string" },
+      { "name": "chainId", "type": "uint256" },
+      { "name": "verifyingContract", "type": "address" }
+    ],
+    "Transaction": [
+      { "name": "from", "type": "address" },
+      { "name": "nonce", "type": "uint256" },
+      { "name": "payload", "type": "TransactionPayload[]" }
+    ],
+    "TransactionPayload": [
+      { "name": "to", "type": "address" },
+      { "name": "value", "type": "uint256" },
+      { "name": "gasLimit", "type": "uint256" },
+      { "name": "data", "type": "bytes" }
+    ]
+  },
+  "primaryType": "Transaction",
+  "domain": {
+    "name": "Account Abstraction Invoker",
+    "version": "1.0.0",
+    "chainId": 0,
+    "verifyingContract": "0x0000000000000000000000000000000000000000"
+  },
+  "message": {
+    "from": "0x0000000000000000000000000000000000000000",
+    "nonce": 0,
+    "payload": [
+      {
+        "to": "0x0000000000000000000000000000000000000000",
+        "value": 0,
+        "gasLimit": 0,
+        "data": "0x"
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
## Motivation

Signing is abstracted away to improve testing DX, but is not explained for outside use.

## Solution

Add docs.