### PR TITLE
fix: balance check, `domainSeparator`, re-entrancy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 ZeroEkkusu.eth
+Copyright (c) 2022 Zero Ekkusu <zeroekkusu.eth>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/contracts/MockContract.sol
+++ b/contracts/MockContract.sol
@@ -23,7 +23,7 @@ contract MockContract {
         delete lastSender;
         delete counter;
 
-        (bool success, ) = msg.sender.call{value: address(this).balance}("");
+        (bool success,) = msg.sender.call{value: address(this).balance}("");
         require(success);
     }
 }

--- a/test/AccountAbstractionInvoker.ts
+++ b/test/AccountAbstractionInvoker.ts
@@ -111,7 +111,7 @@ describe("AccountAbstractionInvoker", () => {
         )
       );
 
-      expect(await invoker.DOMAIN_SEPARATOR()).to.equal(domainSeparator);
+      expect(await invoker.domainSeparator()).to.equal(domainSeparator);
     });
   });
 


### PR DESCRIPTION
## Motivation

Fix identified issues.

## Solution

- Check if the balance of the invoker is less than its starting balance. Useful in the case of `selfdestruct` of another contract.
- Ability to re-compute `DOMAIN_SEPARATOR` in case of a hard fork to prevent replay attacks.
- Add a note about re-entrancy.